### PR TITLE
chore: polish release docs and badges

### DIFF
--- a/.agents/skills/release-flow/SKILL.md
+++ b/.agents/skills/release-flow/SKILL.md
@@ -34,7 +34,7 @@ Examples:
 - If release impact is not `none`, describe the user-visible change in release-note language.
 - Include validation commands and package smoke results.
 - State known boundaries directly, especially peer dependency or `skipLibCheck` requirements.
-- Do not assume npm publication. Release-please can create version/changelog/tag/GitHub release artifacts; npm publish is separate unless a workflow explicitly performs it.
+- Do not assume npm publication. Release-please creates version/changelog/tag/GitHub release artifacts; npm publish is a separate local manual step.
 
 ## Package Publish Rehearsal
 
@@ -54,7 +54,9 @@ Run `bun run publish:npm:dry-run`. It performs the full publish rehearsal:
 10. Typecheck that consumer with `moduleResolution: NodeNext`.
 11. Run a Node ESM import smoke for every public export path.
 
-For the actual npm publish, run `bun run publish:npm`. The script runs the same checks and smoke first, then calls `npm publish --access public` for each package. npm will prompt for a one-time password when account or organization 2FA requires it.
+For the actual npm publish, run `bun run publish:npm` locally from an interactive terminal. The script runs the same checks and smoke first, then calls `npm publish --access public` for each package. npm will prompt for a one-time password when account or organization 2FA requires it.
+
+`publish.ts` is local-only. Do not run `bun run publish:npm` or `bun run publish:npm:dry-run` in GitHub Actions or any other CI job. CI owns verification and release metadata only; local npm publish owns the irreversible registry write.
 
 Publish and release scripts in this repo must use Effect for orchestration. Keep subprocesses, filesystem writes, temp cleanup, tarball checks, and publish steps as `Effect` values with typed failures. Use `Effect.gen` for sequencing, `Effect.forEach` / `Effect.all` for ordered or parallel work, and `Effect.ensuring` for cleanup. Keep `Effect.runPromise` only at the top-level process boundary.
 
@@ -72,6 +74,7 @@ Expected package export paths:
 - If `0.0.1` already exists, the next patch release is `0.0.2`.
 - Prefer letting release-please create version and changelog changes after merge.
 - Do not hand-bump versions unless the user explicitly chooses a manual release path.
+- Do not add npm tokens or trusted publishing to this repo unless the release policy changes explicitly.
 
 ## Safety
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,10 @@ This repository uses release-please-style release automation. Release notes and 
 - Prefer scopes when useful: `core`, `react`, `build`, `ci`, `docs`, `release`.
 - Make PR titles merge-ready Conventional Commit titles.
 - Put release-note context in the PR body when the change should appear in a GitHub release.
-- Release-please creates version/changelog/tag/GitHub-release artifacts; npm publication remains a separate explicit step unless a workflow says otherwise.
-- Before publishing, run a tarball smoke: build, pack, install the `.tgz` files in a clean Bun consumer, typecheck with NodeNext, and run an ESM import smoke.
+- Release-please creates version/changelog/tag/GitHub-release artifacts; npm publication remains a separate local manual step.
+- Never wire npm publish into CI without an explicit release-policy change. Do not add npm tokens or trusted publishing by default.
+- Before publishing, run `bun run publish:npm:dry-run` locally. It builds, packs, installs the `.tgz` files in a clean Bun consumer, typechecks with NodeNext, and runs an ESM import smoke.
+- Publish with `bun run publish:npm` locally from an interactive terminal so npm can prompt for 2FA.
 
 </release-flow>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Frond
 
+[![CI](https://github.com/frondruntime/frond/actions/workflows/ci.yml/badge.svg)](https://github.com/frondruntime/frond/actions/workflows/ci.yml)
+[![core npm](https://badgen.net/npm/v/@frondruntime/core)](https://www.npmjs.com/package/@frondruntime/core)
+[![react npm](https://badgen.net/npm/v/@frondruntime/react)](https://www.npmjs.com/package/@frondruntime/react)
+[![license](https://badgen.net/npm/license/@frondruntime/core)](./LICENSE)
+
 Effect-powered frontend runtime for React and MobX-facing application state.
 
 Frond gives frontend code an explicit runtime graph: keyed node identity, dependency readiness, serialized operations, cancellation, cleanup, eviction, diagnostics, and React Suspense integration.

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,8 +7,8 @@ Use this checklist before publishing `@frondruntime/core` and `@frondruntime/rea
 - Publish only from `master` after CI is green.
 - Keep `@frondruntime/core` and `@frondruntime/react` on the same version unless a release explicitly documents why only one package changes.
 - Keep `packages/react/package.json` peer dependency on `@frondruntime/core` aligned to the release version.
-- GitHub release PRs, tags, and Releases are managed by release-please. npm publish remains manual.
-- Treat npm publish as irreversible. Do not automate publish until the npm organization, 2FA policy, and trusted publishing/token strategy are configured.
+- GitHub release PRs, tags, and Releases are managed by release-please. npm publish remains a local manual step.
+- Treat npm publish as irreversible. Do not automate publish or add npm tokens/trusted publishing until the release policy explicitly changes.
 - Treat public git tags as soft-irreversible. GitHub Releases and tags can be deleted or recreated, but consumers may already have fetched them.
 
 ## Release Metadata
@@ -21,6 +21,8 @@ On each push to `master`, release-please reads Conventional Commits and either:
 - creates GitHub Releases and component tags after the release PR is merged.
 
 The setup intentionally does not publish to npm. After release-please opens a release PR, the workflow checks out that release PR branch and runs `bun install` so `bun.lock` stays aligned with the version bumps.
+
+Do not run `bun run publish:npm` or `bun run publish:npm:dry-run` from GitHub Actions. The publish script is local-only because the final publish step is interactive and may require npm 2FA.
 
 `@frondruntime/core` and `@frondruntime/react` use linked versions. Release-please tracks both packages in `.release-please-manifest.json`, updates workspace peer dependencies through the `node-workspace` plugin, and emits component tags instead of one shared tag.
 
@@ -39,7 +41,7 @@ If CI does not run on release-please PRs, add a repository secret named `RELEASE
 
 ## Local Verification
 
-Run from the repository root:
+Run from the repository root for normal CI-equivalent verification:
 
 ```sh
 bun install --frozen-lockfile
@@ -50,17 +52,13 @@ bun run test
 bun run build
 ```
 
-Verify the package payloads:
+Before a release PR merge or public npm publish, run the full local package rehearsal:
 
 ```sh
-cd packages/core
-bun pm pack --dry-run
-
-cd ../react
-bun pm pack --dry-run
+bun run publish:npm:dry-run
 ```
 
-The dry runs must include `dist`, `src`, `README.md`, and `package.json` for each package. They must not include `node_modules`, test output, local tarballs, or generated workspace artifacts outside the package payload.
+The rehearsal must build, run `npm publish --dry-run` where possible, pack both packages, install the packed tarballs into a clean Bun consumer, typecheck with NodeNext, and run an ESM import smoke. The packed payloads must include `dist`, `src`, `README.md`, and `package.json` for each package. They must not include `node_modules`, test output, local tarballs, or generated workspace artifacts outside the package payload.
 
 ## Versioning
 
@@ -72,14 +70,10 @@ The dry runs must include `dist`, `src`, `README.md`, and `package.json` for eac
 
 ## Manual Publish
 
-After the GitHub Releases and tags exist, publish `core` first, then `react`:
+After the GitHub Releases and tags exist, publish from a local interactive terminal:
 
 ```sh
-cd packages/core
-bun publish --access public --tag latest
-
-cd ../react
-bun publish --access public --tag latest
+bun run publish:npm
 ```
 
-Use a non-`latest` tag, such as `next`, for prereleases.
+The script reruns verification and package smoke before publishing `@frondruntime/core`, then `@frondruntime/react`. npm may prompt for a one-time password for each package.

--- a/publish.ts
+++ b/publish.ts
@@ -50,6 +50,8 @@ Runs the release publish pipeline:
   4. npm pack
   5. clean Bun consumer smoke against packed tarballs
   6. npm publish with interactive 2FA prompt unless --dry-run is set
+
+This script is for local manual release work only. Do not run it in CI.
 `);
   process.exit(0);
 }
@@ -169,6 +171,28 @@ function assertPublishMetadata(
     },
     catch: (cause) =>
       fail("validate package metadata", "Package metadata is not publishable.", cause),
+  });
+}
+
+function assertLocalPublishScript(): Effect.Effect<void, PublishFailure> {
+  return Effect.gen(function* () {
+    if (process.env.CI !== undefined || process.env.GITHUB_ACTIONS !== undefined) {
+      return yield* Effect.fail(
+        fail(
+          "validate publish environment",
+          "publish.ts is local-only. Use CI for verification and release metadata, then publish manually from a local terminal."
+        )
+      );
+    }
+
+    if (!dryRun && process.stdin.isTTY !== true) {
+      return yield* Effect.fail(
+        fail(
+          "validate publish environment",
+          "npm publish requires an interactive terminal so npm can prompt for 2FA. Run bun run publish:npm locally from a TTY."
+        )
+      );
+    }
   });
 }
 
@@ -589,6 +613,8 @@ function publishToNpm(context: PublishContext): Effect.Effect<void, PublishFailu
 }
 
 const program = Effect.gen(function* () {
+  yield* assertLocalPublishScript();
+
   const context = yield* loadPublishContext();
 
   yield* workspaceChecks();


### PR DESCRIPTION
## What changed

- Added root README badges for CI, both npm packages, and MIT license.
- Documented that npm publish is a local manual step, not a GitHub Actions concern.
- Added a publish-script guard that refuses CI and refuses real publish without an interactive terminal for npm 2FA.

## Release impact

none

This is release-process documentation and safety polish. It does not change package runtime behavior or published package contents.

## Validation

- `bun run lint`
- `bun publish.ts --help`
- `env CI=true bun publish.ts --dry-run`
- `bun publish.ts`
