### PR TITLE
fix(build): emit production JSX for published React dist

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -136,6 +136,9 @@ function buildJavaScript(input: PackageBuildInput): Effect.Effect<void, BuildFai
     const result = yield* Effect.tryPromise({
       try: () =>
         Bun.build({
+          // Published dist must emit production JSX (jsx, not jsxDEV), so production
+          // consumers do not crash on the missing dev runtime.
+          define: { "process.env.NODE_ENV": JSON.stringify("production") },
           entrypoints: input.entrypoints.map((entrypoint) => join(input.packageDir, entrypoint)),
           format: "esm",
           keepNames: input.keepNames,


### PR DESCRIPTION
## Summary

- Force Bun package builds to inline `process.env.NODE_ENV` as `production`.
- Ensures `@frondruntime/react` published dist emits `react/jsx-runtime`/`jsx` instead of `react/jsx-dev-runtime`/`jsxDEV`.

## Root cause

`packages/react` had the correct TypeScript JSX config, but `Bun.build` was invoked without a production signal. Bun emitted the development JSX runtime into library artifacts, so production React consumers could crash with `jsxDEV is not a function`.

## Release impact

patch - fixes production consumers of `@frondruntime/react` that load the published dist in production React bundles.

## Validation

- `bun build.ts core react`
- `rg -n "jsxDEV|react/jsx-dev-runtime" packages/react/dist` returned no matches
- `rg -n "react/jsx-runtime" packages/react/dist` confirmed production JSX runtime imports
- `bun run publish:npm:dry-run`

The publish dry-run passed workspace checks, Effect diagnostics, tests, build, package packing, clean tarball install, NodeNext typecheck, and ESM import smoke. No packages were published.