### PR TITLE
chore: release 0.0.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/core": "0.0.2",
-  "packages/react": "0.0.2"
+  "packages/core": "0.0.3",
+  "packages/react": "0.0.3"
 }

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "packages/core": {
       "name": "@frondruntime/core",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "devDependencies": {
         "effect": "4.0.0-beta.90",
         "mobx": "6.15.3",
@@ -35,7 +35,7 @@
     },
     "packages/react": {
       "name": "@frondruntime/react",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "devDependencies": {
         "@frondruntime/core": "workspace:*",
         "@testing-library/react": "16.3.2",
@@ -43,7 +43,7 @@
         "global-jsdom": "29.0.0",
       },
       "peerDependencies": {
-        "@frondruntime/core": "0.0.2",
+        "@frondruntime/core": "0.0.3",
         "effect": "^4.0.0-0",
         "mobx": ">=6 <7",
         "mobx-react-lite": ">=4 <5",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.0.3](https://github.com/frondruntime/frond/compare/core-v0.0.2...core-v0.0.3) (2026-06-30)
+
+
+### Bug Fixes
+
+* emit production JSX for published React dist ([#6](https://github.com/frondruntime/frond/issues/6)) ([af62ac4](https://github.com/frondruntime/frond/commit/af62ac4857c22231b4603765ad16a3535d484f51))
+
 ## [0.0.2](https://github.com/frondruntime/frond/compare/core-v0.0.1...core-v0.0.2) (2026-06-27)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frondruntime/core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Effect-powered Frond runtime core with MobX-facing node state.",
   "license": "MIT",
   "private": false,

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.0.3](https://github.com/frondruntime/frond/compare/react-v0.0.2...react-v0.0.3) (2026-06-30)
+
+
+### Bug Fixes
+
+* emit production JSX for published React dist ([#6](https://github.com/frondruntime/frond/issues/6)) ([af62ac4](https://github.com/frondruntime/frond/commit/af62ac4857c22231b4603765ad16a3535d484f51))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @frondruntime/core bumped to 0.0.3
+  * peerDependencies
+    * @frondruntime/core bumped from 0.0.2 to 0.0.3
+
 ## [0.0.2](https://github.com/frondruntime/frond/compare/react-v0.0.1...react-v0.0.2) (2026-06-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frondruntime/react",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "React adapter for the Effect-powered Frond runtime.",
   "license": "MIT",
   "private": false,
@@ -57,7 +57,7 @@
     "test": "bun --conditions=source test"
   },
   "peerDependencies": {
-    "@frondruntime/core": "0.0.2",
+    "@frondruntime/core": "0.0.3",
     "react": ">=18",
     "effect": "^4.0.0-0",
     "mobx": ">=6 <7",


### PR DESCRIPTION
## Summary

Manual release metadata PR for `@frondruntime/core` and `@frondruntime/react` `0.0.3`.

This is manual because release-please skipped the production JSX fix: the fix commit only touched root `build.ts`, while release-please currently attributes commits by `packages/core` and `packages/react` paths.

## Release notes

### Bug Fixes

- emit production JSX for published React dist ([#6](https://github.com/frondruntime/frond/pull/6))

## Changed files

- bump `packages/core` and `packages/react` to `0.0.3`
- update `.release-please-manifest.json`
- update package changelogs
- update `@frondruntime/react` peer dependency on `@frondruntime/core` to `0.0.3`
- update `bun.lock`

## Validation

- `bun run publish:npm:dry-run`
- `rg -n "jsxDEV|react/jsx-dev-runtime" packages/react/dist` returned no matches
- `rg -n "react/jsx-runtime" packages/react/dist` confirmed production JSX runtime imports

The dry-run passed install, lint, typecheck, Effect diagnostics, tests, build, npm publish dry-run for both `0.0.3` packages, tarball install, NodeNext typecheck, and ESM smoke. No packages were published.