### PR TITLE
chore(release): drop core's self-referential devDependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,6 @@
       "name": "@frondruntime/core",
       "version": "0.1.0",
       "devDependencies": {
-        "@frondruntime/core": "workspace:*",
         "effect": "4.0.0-beta.90",
         "mobx": "6.15.3",
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,7 +66,6 @@
     "url": "https://romanonthego.dev"
   },
   "devDependencies": {
-    "@frondruntime/core": "workspace:*",
     "effect": "4.0.0-beta.90",
     "mobx": "6.15.3"
   }


### PR DESCRIPTION
The release-please run on `master` after #13 aborted before creating a release PR:

```
✔ building graph order, existing package names: @frondruntime/core,@frondruntime/react
❯ visiting @frondruntime/core, path:
✔ visiting @frondruntime/core next
❯ visiting @frondruntime/core, path: @frondruntime/core
Error: release-please failed: found cycle in dependency graph:
```

## Cause

`packages/core/package.json` listed **itself** in its own devDependencies:

```json
"devDependencies": {
  "@frondruntime/core": "workspace:*",
  ...
}
```

Added in 2c8d0d7 (*ship react declarations that reference core instead of duplicating it*), so core's `src/testing/*` and type-contract files could import `@frondruntime/core` by name and the d.ts rollup would emit `@frondruntime/core` references rather than relative paths.

release-please's `node-workspace` plugin walks `devDependencies` when it builds the workspace dependency graph. It reads that entry as a genuine `core → core` edge and fails the entire run — so **neither** package gets a release PR, and 0.2.0 is stuck.

## Fix

Remove the entry. It was never load-bearing: both Node and TypeScript's `NodeNext` resolution support **self-reference by package name** through the `exports` field, with no dependency entry required. Both packages have `exports` maps.

## Verification

Full gate on this branch, plus the specific thing 2c8d0d7 was protecting:

| Check | Result |
| --- | --- |
| `bun run typecheck` (9 projects) | pass |
| `bun run lint` | pass |
| `bun run test` | 561 pass, 0 fail |
| `bun run build` | pass |
| `bun run verify:pack` (packed-tarball consumer smoke) | pass — consumer typecheck + runtime smoke |
| `packages/react/dist/index.d.ts` | still opens `import * as Frond from '@frondruntime/core'` — references core, does not duplicate it |
| `packages/core/dist/index.d.ts` | zero self-references |

So the declaration-parity fix from 2c8d0d7 is fully intact without the self-dep.

## After merge

release-please re-runs on `master` and should produce the **0.2.0** release PR for `@frondruntime/core` and `@frondruntime/react` (both already forced to `0.2.0` by the `release-as` config, which the failed run confirmed it read correctly).

Worth a follow-up: nothing currently prevents the self-dep from being reintroduced, and the failure mode is a hard stop on the release path rather than a gate failure. A cheap assertion in `publish.ts`'s metadata checks — or a lint rule — would catch it at PR time instead of post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
