### PR TITLE
fix: track effect 4.0.0-beta.102 and give the peer range a tested floor

### DIFF
--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -50,7 +50,7 @@
     "@frondruntime/devtools": "0.3.0",
     "@frondruntime/react": "0.3.0",
     "@pppp606/ink-chart": "0.2.7",
-    "effect": "4.0.0-beta.90",
+    "effect": "4.0.0-beta.102",
     "ink": "7.1.1",
     "mobx": "6.15.3",
     "mobx-react-lite": "4.1.1",

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@frondruntime/monorepo",
@@ -11,7 +12,7 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@typescript/native-preview": "7.0.0-dev.20260627.2",
-        "effect": "4.0.0-beta.90",
+        "effect": "4.0.0-beta.102",
         "global-jsdom": "29.0.0",
         "jsdom": "29.1.1",
         "mobx-react-lite": "4.1.1",
@@ -28,11 +29,11 @@
       },
       "dependencies": {
         "@effect/platform-bun": "4.0.0-beta.90",
-        "@frondruntime/core": "0.2.0",
-        "@frondruntime/devtools": "0.2.0",
-        "@frondruntime/react": "0.2.0",
+        "@frondruntime/core": "0.3.0",
+        "@frondruntime/devtools": "0.3.0",
+        "@frondruntime/react": "0.3.0",
         "@pppp606/ink-chart": "0.2.7",
-        "effect": "4.0.0-beta.90",
+        "effect": "4.0.0-beta.102",
         "ink": "7.1.1",
         "mobx": "6.15.3",
         "mobx-react-lite": "4.1.1",
@@ -48,11 +49,11 @@
       "name": "@frondruntime/core",
       "version": "0.3.0",
       "devDependencies": {
-        "effect": "4.0.0-beta.90",
+        "effect": "4.0.0-beta.102",
         "mobx": "6.15.3",
       },
       "peerDependencies": {
-        "effect": "^4.0.0-0",
+        "effect": ">=4.0.0-beta.100 <5.0.0",
         "mobx": ">=6 <7",
       },
     },
@@ -63,11 +64,11 @@
         "@frondruntime/core": "workspace:*",
         "@types/bun": "1.3.14",
         "@types/node": "26.1.1",
-        "effect": "4.0.0-beta.90",
+        "effect": "4.0.0-beta.102",
       },
       "peerDependencies": {
         "@frondruntime/core": "0.3.0",
-        "effect": "^4.0.0-0",
+        "effect": ">=4.0.0-beta.100 <5.0.0",
       },
     },
     "packages/react": {
@@ -76,12 +77,12 @@
       "devDependencies": {
         "@frondruntime/core": "workspace:*",
         "@testing-library/react": "16.3.2",
-        "effect": "4.0.0-beta.90",
+        "effect": "4.0.0-beta.102",
         "global-jsdom": "29.0.0",
       },
       "peerDependencies": {
         "@frondruntime/core": "0.3.0",
-        "effect": "^4.0.0-0",
+        "effect": ">=4.0.0-beta.100 <5.0.0",
         "mobx": ">=6 <7",
         "mobx-react-lite": ">=4 <5",
         "react": ">=18",
@@ -281,7 +282,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "effect": ["effect@4.0.0-beta.90", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-A0U3OE+2oyK/iFG6VYbFj9gwjJ7rFXjgP7qV+m7n/4lOREp9Lfk1///SlGCpX7HRueOCZO1l7aW0KByXuJeiPA=="],
+    "effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
 
     "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260627.2",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "effect": "4.0.0-beta.90",
+    "effect": "4.0.0-beta.102",
     "global-jsdom": "29.0.0",
     "jsdom": "29.1.1",
     "mobx-react-lite": "4.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,14 +59,14 @@
   },
   "peerDependencies": {
     "mobx": ">=6 <7",
-    "effect": "^4.0.0-0"
+    "effect": ">=4.0.0-beta.100 <5.0.0"
   },
   "author": {
     "name": "Roman Dubinin",
     "url": "https://romanonthego.dev"
   },
   "devDependencies": {
-    "effect": "4.0.0-beta.90",
+    "effect": "4.0.0-beta.102",
     "mobx": "6.15.3"
   }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -58,13 +58,13 @@
   },
   "peerDependencies": {
     "@frondruntime/core": "0.3.0",
-    "effect": "^4.0.0-0"
+    "effect": ">=4.0.0-beta.100 <5.0.0"
   },
   "devDependencies": {
     "@frondruntime/core": "workspace:*",
     "@types/bun": "1.3.14",
     "@types/node": "26.1.1",
-    "effect": "4.0.0-beta.90"
+    "effect": "4.0.0-beta.102"
   },
   "author": {
     "name": "Roman Dubinin",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -59,14 +59,14 @@
   "peerDependencies": {
     "@frondruntime/core": "0.3.0",
     "react": ">=18",
-    "effect": "^4.0.0-0",
+    "effect": ">=4.0.0-beta.100 <5.0.0",
     "mobx": ">=6 <7",
     "mobx-react-lite": ">=4 <5"
   },
   "devDependencies": {
     "@frondruntime/core": "workspace:*",
     "@testing-library/react": "16.3.2",
-    "effect": "4.0.0-beta.90",
+    "effect": "4.0.0-beta.102",
     "global-jsdom": "29.0.0"
   },
   "author": {


### PR DESCRIPTION
Stacked on #18 — base retargets to `master` automatically once that merges.

## The report

Effect betas at 100+ were reported to break frond. They do not.

| effect | typecheck | tests | diagnostics | build |
| --- | --- | --- | --- | --- |
| 4.0.0-beta.100 | 0 errors | 740 pass | 0/0/0 | ok |
| 4.0.0-beta.101 | 0 errors | 740 pass | 0/0/0 | ok |
| 4.0.0-beta.102 | 0 errors | 740 pass | 0/0/0 | ok |

None of the API removed between beta.91 and beta.102 is used anywhere in this repo — `Effect.withConcurrency`, `concurrency: "inherit"`, `Schema.asClass`, `Schema.DateValid`, `SchemaUtils`, `SchemaRepresentation`, `Schedule.elapsed`/`tapInput`/`tapOutput`, `HttpApiEndpoint.*`, `UrlParams.makeUrl`. Published `0.3.0` installed clean from npm also runs unmodified against beta.102.

## The real failure at beta.102 is upstream

`effect/dist/Schema.d.ts:10786` declares `ReadonlyArray<SchemaAST.Sentinel>`, and `SchemaAST.d.ts` exports no `Sentinel` — the name survives only in a prose comment. Effect beta.102 ships types that do not typecheck against themselves. Reproduces with no frond:

```ts
import { Schema } from "effect";
export const S = Schema.Struct({ a: Schema.String });
```

Bisected: clean on 90, 99, 100, 101 — fails only on 102. It surfaces only under `skipLibCheck: false`, which is why this repo never saw it (`tsconfig.base.json` sets it true) and why a strict consumer would. Nothing to fix here; it needs a 103.

## What this PR changes

- Pinned effect moves `beta.90` → `beta.102` across the workspace.
- Peer range `^4.0.0-0` → `>=4.0.0-beta.100 <5.0.0` in core, react and devtools.

The old range accepted every 4.0.0 prerelease including unreleased ones, across a series that removed public API in 96, 98 and 102. The new floor is the oldest beta actually verified here, and it stays open through 4.x so effect can move forward without a frond release per beta. Verified matching:

```
4.0.0-beta.90   no      4.0.0-beta.102  MATCH
4.0.0-beta.99   no      4.0.0           MATCH
4.0.0-beta.100  MATCH   5.0.0           no
```

## Verification

Typecheck, lint, effect diagnostics, 740 tests, build, and `verify:pack` — which installs the real tarballs, typechecks them and runs the binary — all pass at beta.102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)